### PR TITLE
Update datetime titles

### DIFF
--- a/fields.json
+++ b/fields.json
@@ -126,7 +126,7 @@
 		"keywords": "Keywords",
 
 		"datetime": {
-			"label": "Acquired",
+			"label": "Datetime",
 			"format": "Timestamp",
 			"summary": false
 		},
@@ -142,12 +142,12 @@
 		},
 
 		"start_datetime": {
-			"label": "First Acquisition",
+			"label": "Start Datetime",
 			"format": "Timestamp",
 			"summary": false
 		},
 		"end_datetime": {
-			"label": "Last Acquisition",
+			"label": "End Datetime",
 			"format": "Timestamp",
 			"summary": false
 		},


### PR DESCRIPTION
The spec for [`datetime`](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#datetime) field mentions that it can be a representative datetime instead of an acquisition datetime.

I suggest to update datetime field titles from "Acquired" to a simple neutral "Datetime", because it can contain any representative datetime depending on the data.

For example, there is a new [forecast](https://github.com/stac-extensions/forecast) extension being drafted which is going to use a forecast datetime in `datetime` field. See https://github.com/stac-extensions/forecast/issues/1 and https://github.com/stac-extensions/forecast/issues/7 for the related discussion.