### PR TITLE
Add filter for child properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,10 @@ function formatGrouped(context, data, type, filter, coreKey) {
 					itemFieldNames = Object.keys(temp);
 				}
 
+				if (typeof filter === 'function') {
+					itemFieldNames = itemFieldNames.filter(filter)
+				}
+
 				items = {};
 				// Remove fields from list that are not available in the data
 				itemOrder = spec.itemOrder.filter(fieldName => itemFieldNames.includes(fieldName));


### PR DESCRIPTION
For the `StacFields.formatItemProperties` method I was interested in being able to add filters at a lower depth for properties (eg filtering out `raster:bands.histogram`).

The proposed approach in the 1st commit of this PR works for level 2 of the properties, but it would be nice to pass in any key, no matter the depth, and have it work (eg `raster:bands.histogram.buckets`) - but I haven't quite worked out entirely how the logic of how this library works in traversing the tree so I've just done what I can understand ATM...

The other thing to be considered would be the best notation or API for this more advanced filtering - currently the filter function just provides the key, but what if the same key is used multiple times in a deeply nested structure? So perhaps nested keys ought to passed into the function with a dot notation or something, eg
````
const out = StacFields.formatItemProperties(data, key => {
  return key !== 'raster:bands.histogram'
})
// RATHER THAN
const out = StacFields.formatItemProperties(data, key => {
  return key !== 'histogram'
})
````
Or maybe there there is an alternate approach...

Anyway open to thoughts & suggestions