### PR TITLE
Update label for pl extension

### DIFF
--- a/fields.json
+++ b/fields.json
@@ -50,7 +50,7 @@
 		"landsat": "Landsat",
 		"msft": "Microsoft",
 		"openeo": "openEO",
-		"pl": "Planet Labs Inc.",
+		"pl": "Planet Labs PBC",
 		"sentinel": "Copernicus Sentinel",
 		"cbers": {
 			"label": "CBERS",


### PR DESCRIPTION
This updates the company name for the `pl` extension to Planet Labs PBC.

Should the source of truth for this be the extension schema?  Released versions of this schema are now available at https://planetlabs.github.io/stac-extension/.