### PR TITLE
Add proj:code

### DIFF
--- a/fields.json
+++ b/fields.json
@@ -1124,6 +1124,11 @@
 			"format": "EPSG",
 			"summary": "v"
 		},
+		"proj:code": {
+			"label": "Code",
+			"explain": "Proj code. For example: EPSG:4326",
+			"summary": "v"
+		},
 		"proj:wkt2": {
 			"label": "WKT2",
 			"explain": "Well-Known Text, version 2",


### PR DESCRIPTION
Closes #26. 

I imagine the old proj:epsg should stay in there for now since there doesn't seem to be any extension version information.