### PR TITLE
Fix localization issues (e.g. rounding)

### DIFF
--- a/I18N.js
+++ b/I18N.js
@@ -23,10 +23,10 @@ const Defaults = {
 const I18N = {
 
 	locales: [],
-	collator: new Intl.Collator(Defaults.collatorOptions),
-	dateFormatter: new Intl.DateTimeFormat(Defaults.dateFormatterOptions),
-	dateTimeFormatter: new Intl.DateTimeFormat(Defaults.dateTimeFormatterOptions),
-	numberFormatter: new Intl.NumberFormat(Defaults.numberFormatterOptions),
+	collator: new Intl.Collator(this.locales, Defaults.collatorOptions),
+	dateFormatter: new Intl.DateTimeFormat(this.locales, Defaults.dateFormatterOptions),
+	dateTimeFormatter: new Intl.DateTimeFormat(this.locales, Defaults.dateTimeFormatterOptions),
+	numberFormatter: new Intl.NumberFormat(this.locales, Defaults.numberFormatterOptions),
 	translate: null, // function(value: string, vars: array|object = null) : string
 
 	getDefaults() {


### PR DESCRIPTION
The format options were sent to the wrong function argument (the first parameter is `locales`). Please confirm that `this.locales` is the right thing to insert there -- it worked to fix the issue, but idk if there's more elaborate functionality so I couldn't test for that.