### PR TITLE
Parse URLs as links 

### DIFF
--- a/datatypes.js
+++ b/datatypes.js
@@ -26,12 +26,13 @@ const DataTypes = {
 	},
 
 	string(str, unit = '') {
-		try {
-			const url = new URL(str);
-			return _.toLink(url.toString(), url.toString())
-		} catch (exception) {
-			return _.unit(_.e(str).replace(/(\r\n|\r|\n){2,}/g, '<br>'), unit);
+		if(str.startsWith("http://") || str.startsWith("https://")){
+			try {
+				const url = new URL(str);
+				return _.toLink(url.toString(), url.toString())
+			} catch (exception) {}
 		}
+		return _.unit(_.e(str).replace(/(\r\n|\r|\n){2,}/g, '<br>'), unit);
 	},
 	
 	boolean(bool) {

--- a/datatypes.js
+++ b/datatypes.js
@@ -27,7 +27,7 @@ const DataTypes = {
 
 	string(str, unit = '') {
 		try {
-			const url = new URL(string);
+			const url = new URL(str);
 			return _.toLink(url.toString(), url.toString())
 		} catch (exception) {
 			return _.unit(_.e(str).replace(/(\r\n|\r|\n){2,}/g, '<br>'), unit);

--- a/datatypes.js
+++ b/datatypes.js
@@ -26,7 +26,12 @@ const DataTypes = {
 	},
 
 	string(str, unit = '') {
-		return _.unit(_.e(str).replace(/(\r\n|\r|\n){2,}/g, '<br>'), unit);
+		try {
+			const url = new URL(string);
+			return _.toLink(url.toString(), url.toString())
+		} catch (_) {
+			return _.unit(_.e(str).replace(/(\r\n|\r|\n){2,}/g, '<br>'), unit);
+		}
 	},
 	
 	boolean(bool) {

--- a/datatypes.js
+++ b/datatypes.js
@@ -29,7 +29,7 @@ const DataTypes = {
 		try {
 			const url = new URL(string);
 			return _.toLink(url.toString(), url.toString())
-		} catch (_) {
+		} catch (exception) {
 			return _.unit(_.e(str).replace(/(\r\n|\r|\n){2,}/g, '<br>'), unit);
 		}
 	},


### PR DESCRIPTION
When parsing a string datatype, if the string is a valid URL, create a valid HTML link instead of printing the string.
This is useful in many situations, for example in the STAC browser, when a geojson has attributes that are URLs they are interactive.