### PR TITLE
add cf extension to fields

### DIFF
--- a/fields.json
+++ b/fields.json
@@ -7,6 +7,7 @@
 			"label": "CARD4L",
 			"explain": "CEOS Analysis Ready Data for Land"
 		},
+		"cf": "CF Metadata Conventions",
 		"classification": "Classification",
 		"contacts": "Contacts",
 		"cube": "Data Cube",


### PR DESCRIPTION
Add https://github.com/stac-extensions/cf to avoid "Cf" being used by default when viewing the items.

