### PR TITLE
add rel license field

### DIFF
--- a/fields.json
+++ b/fields.json
@@ -117,7 +117,8 @@
 				"tilejson": "TileJSON",
 				"wms": "OGC Web Map Service (WMS)",
 				"wmts": "OGC Web Map Tile Service (WMTS)",
-				"xyz": "XYZ Web Map"
+				"xyz": "XYZ Web Map",
+				"license": "License"
 			}
 		},
 		"type": {


### PR DESCRIPTION
Add `license` to `links.rel` in `fields.json` to enable license rel links to be visible in stac browser. license is one of the possible rel type defined in [this list](https://www.iana.org/assignments/link-relations/link-relations.xhtml) based the [rel specification](https://github.com/radiantearth/stac-spec/blob/master/commons/links.md#relation-types)